### PR TITLE
Fixed react-native peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "react": "^16.8 || ^17 || ^18",
-    "react-native": ">=64"
+    "react-native": ">=0.71.6"
   },
   "dependencies": {
     "@rozhkov/react-useful-hooks": "^1.0.8"


### PR DESCRIPTION
Right now installation fails since it requires a react-native peer higher than the latest version.