### PR TITLE
fix: the items at the top/bottom disappear abruptly when scrolling on Android (#17)

### DIFF
--- a/src/base/list/List.tsx
+++ b/src/base/list/List.tsx
@@ -98,6 +98,7 @@ const List = <ItemT extends PickerItem<any>>(
       onTouchEnd={onTouchEnd}
       onTouchCancel={onTouchCancel}
       nestedScrollEnabled={true}
+      removeClippedSubviews={false}
     >
       {data.map((item, index) =>
         renderItem({key: keyExtractor(item, index), item, index}),

--- a/src/hoc/virtualized/VirtualizedList.tsx
+++ b/src/hoc/virtualized/VirtualizedList.tsx
@@ -109,6 +109,7 @@ const VirtualizedList = <ItemT extends PickerItem<any>>(
       updateCellsBatchingPeriod={updateCellsBatchingPeriod}
       windowSize={windowSize}
       nestedScrollEnabled={true}
+      removeClippedSubviews={false}
     />
   );
 };


### PR DESCRIPTION
This is due to the fact that FlatList thinks that the elements have gone beyond the container, although in fact this is not the case: we want to animate the elements further with this.