### PR TITLE
feat: add extraValues prop for additional synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ const App = () => {
 - ```width?``` [number | string] - width of picker.
 - ```readOnly?``` [boolean] - read only mode.
 - ```enableScrollByTapOnItem?``` [boolean] - allow scrolling by tap on an item (default = false)
+- ```extraValues?``` [unknown[]] - external values on which the Picker depends. Can be used as a forced trigger for scroll synchronization, even if it is active
 - ```testID?``` [string] - Used to locate this component in end-to-end tests.
 - ```onValueChanging?``` [function] - An event that is triggered when the value is changing.
 - ```onValueChanged?``` [function] - An event that is triggered when the value is changed (wheel is stopped and no touch).

--- a/src/base/picker/Picker.tsx
+++ b/src/base/picker/Picker.tsx
@@ -28,6 +28,7 @@ import List from '../list/List';
 export type PickerProps<ItemT extends PickerItem<any>> = {
   data: ReadonlyArray<ItemT>;
   value?: ItemT['value'];
+  extraValues?: unknown[];
   itemHeight?: number;
   visibleItemCount?: number;
   width?: number | 'auto' | `${number}%`;
@@ -82,6 +83,7 @@ const useValueIndex = (data: ReadonlyArray<PickerItem<any>>, value: any) => {
 const Picker = <ItemT extends PickerItem<any>>({
   data,
   value,
+  extraValues = [],
   width = 'auto',
   itemHeight = 48,
   visibleItemCount = 5,
@@ -152,6 +154,7 @@ const Picker = <ItemT extends PickerItem<any>>({
     listRef,
     value,
     valueIndex,
+    extraValues,
     activeIndexRef,
     touching: touching.value,
   });

--- a/src/base/picker/hooks/useSyncScrollEffect.ts
+++ b/src/base/picker/hooks/useSyncScrollEffect.ts
@@ -1,17 +1,20 @@
 import {type RefObject, useEffect, useRef} from 'react';
 import {useStableCallback} from '@rozhkov/react-useful-hooks';
+import {useEffectWithDynamicDepsLength} from '@utils/react';
 import type {ListMethods} from '../../types';
 
 const useSyncScrollEffect = ({
   listRef,
   value,
   valueIndex,
+  extraValues = [],
   activeIndexRef,
   touching,
 }: {
   listRef: RefObject<ListMethods>;
   value: unknown;
   valueIndex: number;
+  extraValues: unknown[] | undefined;
   activeIndexRef: RefObject<number>;
   touching: boolean;
 }) => {
@@ -30,6 +33,10 @@ const useSyncScrollEffect = ({
   useEffect(() => {
     syncScroll();
   }, [valueIndex]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffectWithDynamicDepsLength(() => {
+    syncScroll();
+  }, extraValues);
 
   const timeoutId = useRef<any>(undefined);
   const onScrollEnd = useStableCallback(() => {

--- a/src/utils/react/index.ts
+++ b/src/utils/react/index.ts
@@ -1,2 +1,3 @@
 export {default as typedMemo} from './typedMemo';
 export {default as useBoolean} from './useBoolean';
+export {default as useEffectWithDynamicDepsLength} from './useEffectWithDynamicDepsLength';

--- a/src/utils/react/useEffectWithDynamicDepsLength.ts
+++ b/src/utils/react/useEffectWithDynamicDepsLength.ts
@@ -1,0 +1,35 @@
+import {useEffect} from 'react';
+import {usePrevious, useStableCallback} from '@rozhkov/react-useful-hooks';
+
+const areArraysShallowEqual = (
+  arr1: unknown[] | undefined,
+  arr2: unknown[] | undefined,
+): boolean => {
+  if (arr1 === arr2) return true;
+  if (!arr1 || !arr2) return false;
+
+  if (arr1.length !== arr2.length) return false;
+
+  for (let i = 0; i < arr1.length; i++) {
+    if (arr1[i] !== arr2[i]) return false;
+  }
+
+  return true;
+};
+
+const useEffectWithDynamicDepsLength = (
+  callback: () => void,
+  deps: unknown[],
+) => {
+  const prevDeps = usePrevious(deps);
+
+  const callbackStable = useStableCallback(callback);
+
+  useEffect(() => {
+    if (!areArraysShallowEqual(prevDeps, deps)) {
+      callbackStable();
+    }
+  }, [deps]); // eslint-disable-line react-hooks/exhaustive-deps
+};
+
+export default useEffectWithDynamicDepsLength;


### PR DESCRIPTION
Added a new prop that lets you pass into WheelPicker values that depend on external WheelPickers. You can use this for forced scroll synchronization when the values change. 

This fixes issue #36.