### PR TITLE
feat: expose `disableIntervalMomentum` as opt-in Picker prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ const App = () => {
 - ```overlayItemStyle?``` [object | array] - style for the overlay element in the center
 - ```contentContainerStyle?``` [object | array] - style which wraps all of the child views [original](https://reactnative.dev/docs/scrollview#contentcontainerstyle)
 - ```scrollEventThrottle?``` [object | array] - [original](https://reactnative.dev/docs/scrollview#scrolleventthrottle-ios)
+- ```disableIntervalMomentum?``` [boolean] - When set to `true`, the scroll view stops on the next snap point relative to the release position instead of carrying through with momentum. Useful as an opt-in workaround for a [react-native bug](https://github.com/facebook/react-native/issues/29922) where some older Android OEM devices (e.g. vivo / Oppo) produce erratic snap behavior. Defaults to React Native's default (off).
 
 
 #### usePickerItemHeight

--- a/src/base/list/List.tsx
+++ b/src/base/list/List.tsx
@@ -42,6 +42,7 @@ export type ListProps<ItemT extends PickerItem<any>> = {
   onScrollStart: (() => void) | undefined;
   onScrollEnd: () => void;
   contentContainerStyle: StyleProp<ViewStyle> | undefined;
+  disableIntervalMomentum?: boolean;
 };
 
 const List = <ItemT extends PickerItem<any>>(
@@ -60,6 +61,7 @@ const List = <ItemT extends PickerItem<any>>(
     onScrollStart,
     onScrollEnd,
     contentContainerStyle: contentContainerStyleProp,
+    disableIntervalMomentum,
     ...restProps
   }: ListProps<ItemT>,
   forwardedRef: ForwardedRef<ListMethods>,
@@ -116,6 +118,7 @@ const List = <ItemT extends PickerItem<any>>(
       onScroll={onScroll}
       scrollOffset={scrollOffset}
       snapToOffsets={snapToOffsets}
+      disableIntervalMomentum={disableIntervalMomentum}
       style={styles.list}
       contentContainerStyle={contentContainerStyle}
       onTouchStart={onTouchStart}

--- a/src/base/picker/Picker.tsx
+++ b/src/base/picker/Picker.tsx
@@ -58,6 +58,7 @@ export type PickerProps<ItemT extends PickerItem<any>> = {
   contentContainerStyle?: StyleProp<ViewStyle>;
 
   scrollEventThrottle?: number;
+  disableIntervalMomentum?: boolean;
 
   _enableSyncScrollAfterScrollEnd?: boolean;
   _onScrollStart?: () => void;

--- a/src/hoc/virtualized/VirtualizedList.tsx
+++ b/src/hoc/virtualized/VirtualizedList.tsx
@@ -49,6 +49,7 @@ type VirtualizedListProps<ItemT extends PickerItem<any>> = {
   onScrollStart: (() => void) | undefined;
   onScrollEnd: () => void;
   contentContainerStyle: StyleProp<ViewStyle> | undefined;
+  disableIntervalMomentum?: boolean;
 } & AdditionalProps;
 
 const VirtualizedList = <ItemT extends PickerItem<any>>(
@@ -73,6 +74,8 @@ const VirtualizedList = <ItemT extends PickerItem<any>>(
     maxToRenderPerBatch,
     updateCellsBatchingPeriod = 10,
     windowSize,
+
+    disableIntervalMomentum,
 
     ...restProps
   }: VirtualizedListProps<ItemT>,
@@ -123,6 +126,7 @@ const VirtualizedList = <ItemT extends PickerItem<any>>(
       onScroll={onScroll}
       scrollOffset={scrollOffset}
       snapToOffsets={snapToOffsets}
+      disableIntervalMomentum={disableIntervalMomentum}
       style={styles.list}
       contentContainerStyle={contentContainerStyle}
       onTouchStart={onTouchStart}


### PR DESCRIPTION
Relates to #74.

> Updated per @rozhkovs's review on the previous revision of this PR — `disableIntervalMomentum` is now an explicit opt-in prop instead of a default-on change.

### What

Adds an optional `disableIntervalMomentum?: boolean` prop to `<Picker />` (in `PickerProps`), threaded through to:

- **`src/base/list/List.tsx`** — the regular `Animated.ScrollView` path.
- **`src/hoc/virtualized/VirtualizedList.tsx`** — the virtualized `Animated.FlatList` path. (Both already use `snapToOffsets`, so the prop applies on either path, as @rozhkovs requested.)

Default is `undefined`, which falls back to React Native's default (off). Existing UX is unchanged for everyone.

```jsx
<Picker disableIntervalMomentum />
```

### Why

On some older Android devices (reproduced on **vivo V2002A / Android 10**, and previously reported upstream on vivo / Oppo phones — see [facebook/react-native#29922](https://github.com/facebook/react-native/issues/29922)) the wheel exhibits erratic jumping snap behavior: it doesn't settle on the released item, jumping back and forth across multiple items before stopping, sometimes landing on a value the user never visually crossed.

Setting `disableIntervalMomentum={true}` eliminates the bug on those devices. Exposing it as an opt-in prop lets affected consumers apply the workaround without changing the picker's interaction semantics for the rest of the user base — which is the right tradeoff, since fast flicks still need to carry through multiple items on healthy devices.

### Files

- `src/base/picker/Picker.tsx` — add `disableIntervalMomentum?: boolean` to `PickerProps`. (Flows through `...restProps` to the renderList.)
- `src/base/list/List.tsx` — add the prop to `ListProps`, destructure, pass to the scroll view.
- `src/hoc/virtualized/VirtualizedList.tsx` — same, for the FlatList path.
- `README.md` — document the new prop under WheelPicker Props.

### Test plan

- [x] `yarn tsc:check` — clean.
- [x] `yarn test:run` — 15 tests passing.
- [x] Manually verified on the affected device (vivo V2002A, Android 10) — wheel now settles cleanly when the prop is enabled.
- [x] Verified that with the prop omitted, behavior on iOS / recent Android is unchanged.
