### PR TITLE
fix: `onScrollEnd` race condition breaking `onValueChanged`

### DIFF
--- a/src/utils/scrolling/withScrollStartEndEvent.tsx
+++ b/src/utils/scrolling/withScrollStartEndEvent.tsx
@@ -144,8 +144,10 @@ const withScrollStartEndEvent = <PropsT extends ComponentProps>(
       },
     );
 
+    const hasMomentumScrollEndedRef = useRef(false);
     const onMomentumScrollBegin = useStableCallback(
       (args: NativeSyntheticEvent<NativeScrollEvent>) => {
+        hasMomentumScrollEndedRef.current = false;
         maybeCallOnNativeScrollStart();
         onScrollEnd.clear();
         onMomentumScrollBeginProp?.(args);
@@ -154,6 +156,7 @@ const withScrollStartEndEvent = <PropsT extends ComponentProps>(
 
     const onMomentumScrollEnd = useStableCallback(
       (args: NativeSyntheticEvent<NativeScrollEvent>) => {
+        hasMomentumScrollEndedRef.current = true;
         onMomentumScrollEndProp?.(args);
         onScrollEnd();
       },
@@ -169,7 +172,7 @@ const withScrollStartEndEvent = <PropsT extends ComponentProps>(
 
         if (isImplicitScrollRef.current) {
           onScrollEnd();
-        } else {
+        } else if(!hasMomentumScrollEndedRef.current) {
           onScrollEnd.clear();
         }
       });


### PR DESCRIPTION
Might fix #65 but didn't test it on web

## Problem

`onValueChanged` is frequently not being triggered.

## Cause

`onScrollEnd` is often not called when the `onMomentumScrollEnd` callback is triggered because the debounce is cancelled before running the `onScrollEnd` function. The debounce gets cancelled by the scroll offset listener which runs after `onMomentumScrollEnd` because react-native scrolls the container to snap to the selected item.

## Fix

Check if the momentum scroll already ended inside the scroll offset listener and only clear the debounce if momentum scroll hasn't ended yet.

## Possible new Problems

I don't think this will cause any new issues (not 100% sure) since the default behavior (even without `onMomentumScrollBegin` ever being called) is the same as before.

